### PR TITLE
Update project description, codeowner, and contribution policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners
+* @mdn/core-yari-content

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# These owners are the default owners for everything in this repo.
-* @schalkneethling

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contribution to this repository
+# Contributing to this repository
 
 Thanks for your interest in contributing to MDN!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,60 +1,9 @@
-# Contribution guide
+# Contribution to this repository
 
-![github-profile](https://user-images.githubusercontent.com/10350960/166113119-629295f6-c282-42c9-9379-af2de5ad4338.png)
+Thanks for your interest in contributing to MDN!
 
-- [Ways to contribute](#ways-to-contribute)
-- [Finding an issue](#finding-an-issue)
-- [Asking for help](#asking-for-help)
-- [Pull request process](#pull-request-process)
-- [Forking and cloning the project](#forking-and-cloning-the-project)
+This repository is part of MDN's learning tutorial.
+It provides a fixed example site that learners can refer to.
+For this reason, we are **not accepting pull requests or other contributions** to this repository.
 
-Welcome 👋 Thank you for your interest in contributing to MDN Web Docs. We are happy to have you join us! 💖
-
-As you get started, you are in the best position to give us feedback on project areas we might have forgotten about or assumed to work well.
-These include, but are not limited to:
-
-- Problems found while setting up a new developer environment
-- Gaps in our documentation
-- Bugs in our automation scripts
-
-If anything doesn't make sense or work as expected, please open an issue and let us know!
-
-## Ways to contribute
-
-We welcome many different types of contributions including:
-
-- Identifying and filing issues.
-- Providing feedback on existing issues.
-- Engaging with the community and answering questions.
-- Contributing documentation or code.
-- Promoting the project in personal circles and social media.
-
-## Finding an issue
-
-We have issues labeled `good first issue` for new contributors and `help wanted` suitable for any contributor.
-Good first issues have extra information to help you make your first contribution a success.
-Help wanted issues are ideal when you feel a bit more comfortable with the project details.
-
-Sometimes there won't be any issues with these labels, but there is likely still something for you to work on.
-If you want to contribute but don't know where to start or can't find a suitable issue, speak to us on [Matrix](https://matrix.to/#/#mdn:mozilla.org), and we will be happy to help.
-
-Once you find an issue you'd like to work on, please post a comment saying you want to work on it.
-Something like "I want to work on this" is fine.
-Also, mention the community team using the `@mdn/mdn-community-engagement` handle to ensure someone will get back to you.
-
-## Asking for help
-
-The best way to reach us with a question when contributing is to use the following channels in the following order of precedence:
-
-- [Start a discussion](https://github.com/orgs/mdn/discussions)
-- Ask your question or highlight your discussion on [Matrix](https://matrix.to/#/#mdn:mozilla.org).
-- File an issue and tag the community team using the `@mdn/mdn-community-engagement` handle.
-
-## Pull request process
-
-The MDN Web Docs project has a well-defined pull request process which is documented in the [Pull request guidelines](https://developer.mozilla.org/en-US/docs/MDN/Community/Pull_requests).
-Make sure you read and understand this process before you start working on a pull request.
-
-## Forking and cloning the project
-
-The first step in setting up your development environment is to [fork the repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo) and [clone](https://docs.github.com/en/get-started/quickstart/fork-a-repo#cloning-your-forked-repository) the repository to your local machine.
+If you find an issue with the [learning material itself](https://developer.mozilla.org/en-US/docs/Learn_web_development/Getting_started/Your_first_website/Creating_the_content), you can open an issue or pull request on [MDN's content repository](https://github.com/mdn/content).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in contributing to MDN!
 
-This repository is part of MDN's learning tutorial.
+This repository contains the code used in MDN's "[HTML: Creating the content](/en-US/docs/Learn_web_development/Getting_started/Your_first_website/Creating_the_content)" tutorial.
 It provides a fixed example site that learners can refer to.
 For this reason, we are **not accepting pull requests or other contributions** to this repository.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Beginner HTML Site
 
-This is a simple one-page website created to help beginners learn the basics of HyperText Markup Language (HTML).
+This is a basic one-page website to help beginners learn the fundamentals of HTML.
 You can follow this code while learning from the [HTML basics](https://developer.mozilla.org/en-US/Learn/Getting_started_with_the_web/HTML_basics) course.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Beginner HTML Site
 
-A simple one page website created to help complete beginners learn HyperText Markup Language (HTML) basics. This example is built up over the [HTML basics course](https://developer.mozilla.org/en-US/Learn/Getting_started_with_the_web/HTML_basics).
+This is a simple one-page website created to help beginners learn the basics of HyperText Markup Language (HTML).
+You can follow this code while learning from the [HTML basics](https://developer.mozilla.org/en-US/Learn/Getting_started_with_the_web/HTML_basics) course.


### PR DESCRIPTION
This PR updates the project defaults to reflect the intended use of the repository.

- `CODEOWNERS`: Moved to `.github` folder for consistency with other MDN repos and also updated the default team
- `CONTRIBUTING.md`: Updated to clarify that we're not accepting PRs to change the code, unless there is a bug
- `README`: Simplified and clarified